### PR TITLE
updates jQuery snippet to work with v1.11.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,7 @@ __img__
 __jquery__
 
 ```html
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
-<script>window.jQuery || document.write('<script src="js/vendor/jquery-1.8.3.min.js"><\/script>')</script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
 ```
 
 __lorem__

--- a/jquery.sublime-snippet
+++ b/jquery.sublime-snippet
@@ -1,6 +1,5 @@
 <snippet>
-	<content><![CDATA[<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
-<script>window.jQuery || document.write('<script src="js/vendor/jquery-1.8.3.min.js"><\/script>')</script>]]></content>
+	<content><![CDATA[<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>]]></content>
 	<tabTrigger>jquery</tabTrigger>
 	<description>HTML - Include jQuery</description>
 	<scope>text.html</scope>


### PR DESCRIPTION
The actual version of the snippet didn't work for me because it misses the "https:" in the source link. This change fixes it and changes the jQuery version to 1.11.3 (currently the snippet uses 1.8.3).

I hope you find it useful. Thanks!
